### PR TITLE
Initial 24/7 streaming scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Proyecto de Streaming 24/7 con OneDrive y HLS
+
+Este proyecto monta una carpeta de OneDrive en un VPS y utiliza `ffmpeg` como broadcaster para emitir una lista de videos de forma continua hacia un servidor de streaming. El servidor convierte la señal en HLS para incrustarla en una página web.
+
+## Componentes
+
+- **rclone**: monta OneDrive como si fuese un disco local.
+- **ffmpeg**: reproduce en bucle los videos y envía la señal al servidor de streaming.
+- **nginx-rtmp**: recibe la señal RTMP y genera segmentos HLS (`m3u8` y `ts`).
+- **hls.js**: reproductor web para visualizar la transmisión.
+
+## Uso rápido
+
+1. Configura `rclone` con tu cuenta de OneDrive.
+2. Monta tu nube:
+   ```bash
+   rclone mount onedrive: /mnt/onedrive &
+   ```
+3. Instala Nginx con el módulo RTMP (en Debian/Ubuntu):
+   ```bash
+   sudo apt install nginx libnginx-mod-rtmp
+   ```
+4. Copia `nginx.conf` a `/etc/nginx/nginx.conf` o incluye su contenido en tu configuración y reinicia el servicio:
+   ```bash
+   sudo cp nginx.conf /etc/nginx/nginx.conf
+   sudo systemctl restart nginx
+   ```
+5. Ejecuta el script de emisión (o instala `stream.service` para correrlo como servicio):
+   ```bash
+   ./scripts/stream.sh /mnt/onedrive/playlist.txt rtmp://localhost:1935/live/stream
+   ```
+6. Abre `web/index.html` en tu navegador para reproducir la transmisión.
+
+## Estructura
+
+- `scripts/stream.sh`: script que usa `ffmpeg` para emitir en bucle.
+- `nginx.conf`: configuración mínima para `nginx-rtmp`.
+- `stream.service`: ejemplo de unidad `systemd` para el script de emisión.
+- `web/index.html`: página de ejemplo con `hls.js`.
+
+## Requisitos
+
+- `rclone`
+- `ffmpeg`
+- `nginx` con módulo `rtmp`
+- Navegador moderno compatible con `hls.js`

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes 1;
+
+error_log  /var/log/nginx/error.log warn;
+
+rtmp {
+    server {
+        listen 1935;
+        application live {
+            live on;
+            record off;
+            hls on;
+            hls_path /tmp/hls;
+            hls_fragment 3;
+            hls_playlist_length 10;
+        }
+    }
+}
+
+http {
+    server {
+        listen 80;
+        location /hls {
+            types {
+                application/vnd.apple.mpegurl m3u8;
+                video/mp2t ts;
+            }
+            root /tmp;
+            add_header Cache-Control no-cache;
+        }
+    }
+}

--- a/scripts/stream.sh
+++ b/scripts/stream.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Emite en bucle una lista de videos hacia un servidor RTMP.
+# Uso: ./stream.sh PLAYLIST RTMP_URL
+
+set -e
+PLAYLIST="$1"
+RTMP_URL="$2"
+
+if [ -z "$PLAYLIST" ] || [ -z "$RTMP_URL" ]; then
+  echo "Uso: $0 PLAYLIST RTMP_URL" >&2
+  exit 1
+fi
+
+while true; do
+  while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+    ffmpeg -re -i "$FILE" -c copy -f flv "$RTMP_URL"
+  done < "$PLAYLIST"
+  sleep 1
+done

--- a/stream.service
+++ b/stream.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FFmpeg loop broadcaster
+After=network-online.target
+
+[Service]
+Type=simple
+# Ajusta la ruta al script y la lista de reproducción
+ExecStart=/usr/local/bin/stream.sh /mnt/onedrive/playlist.txt rtmp://localhost:1935/live/stream
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Streaming HLS</title>
+</head>
+<body>
+  <video id="video" controls autoplay style="width:100%;max-width:800px;"></video>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <script>
+    const video = document.getElementById('video');
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hls.loadSource('http://localhost:8080/hls/stream.m3u8');
+      hls.attachMedia(video);
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      video.src = 'http://localhost:8080/hls/stream.m3u8';
+    } else {
+      video.outerHTML = '<p>Tu navegador no soporta HLS.</p>';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Drop Docker usage and describe service-based setup
- Add example systemd unit for ffmpeg loop broadcaster
- Guide installing nginx-rtmp directly and restarting the service

## Testing
- `bash -n scripts/stream.sh`
- `nginx -t -c $(pwd)/nginx.conf` (fails: command not found)
- `systemd-analyze verify stream.service` (fails: /usr/local/bin/stream.sh not executable)


------
https://chatgpt.com/codex/tasks/task_e_68b85723012c8328b33da8a38d022c85